### PR TITLE
Fix Pages deployment: trigger workflow on master branch

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -2,7 +2,7 @@ name: Deploy Hugo site to Pages
 
 on:
   push:
-    branches: ["main", "hugo-hextra-rewrite"]
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

The Hugo build workflow was configured to trigger on pushes to `main`, but the repository's default branch is `master`. This meant the workflow never fired, and only the default "pages build and deployment" ran — which served raw source files as a placeholder page.

**Changes:**
- Updated `.github/workflows/hugo.yaml` to trigger on `master` instead of `main`/`hugo-hextra-rewrite`
- GitHub Pages source has already been switched from "Deploy from branch" to "GitHub Actions" via the API

Once merged, the push to `master` will trigger the Hugo build and deploy the actual site to https://project-koku.github.io/.


Made with [Cursor](https://cursor.com)